### PR TITLE
node-zip no loger shows these errors in debug mode

### DIFF
--- a/lib/nodezip.js
+++ b/lib/nodezip.js
@@ -1,7 +1,8 @@
 var fs = require('fs');
 var vm = require('vm');
 var loadVendor = function(js) {
-    vm.runInThisContext(fs.readFileSync(__dirname+'/../vendor/'+js), js);
+	var path = fs.realpathSync(__dirname+'/../vendor/'+js);
+    vm.runInThisContext(fs.readFileSync(path), path);
 }.bind(this);
 
 loadVendor('jszip/jszip.js');


### PR DESCRIPTION
{ [Error: ENOENT, no such file or directory 'C:\Work\pool-3-mobile\trunk\Pool-Live-Tour\PoolLiveTour2\assets\asset-versioner\jszip\jszip.js']
  errno: 34,
  code: 'ENOENT',
  path: 'C:\Work\pool-3-mobile\trunk\Pool-Live-Tour\PoolLiveTour2\assets\asset-versioner\jszip\jszip.js',
  syscall: 'open' }
