### PR TITLE
Update to JSZip 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "lib/nodezip.js",
   "dependencies": {
-    "jszip" : "2.1.1"
+    "jszip" : "2.2.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
From the changelog : 
- make the new operator optional before the JSZip constructor.
- update zlibjs to v0.2.0.

The zlibjs upgrade fixes a bug and a size issue (the previous zlibjs release was too big).
