### PR TITLE
Update to JSZip 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "lib/nodezip.js",
   "dependencies": {
-    "jszip" : "2.2.0"
+    "jszip" : "2.2.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
From the changelog :
- fix unreadable generated file on Windows 8
- replace zlibjs with pako.
