### PR TITLE
Add license property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": {
     "url": "git://github.com/daraosn/node-zip.git"
   },
+  "license": "MIT",
   "contributors": [
     {
       "name": "David Duponchel",


### PR DESCRIPTION
This tiny PR adds `{"license":"MIT"}` to `package.json` so software license checking tools can whitelist node-zip.

Thanks!

K