### PR TITLE
Upgrade jszip to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "main": "lib/nodezip.js",
   "dependencies": {
-    "jszip" : "2.5.0"
+    "jszip" : "2.6.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
The license field is not SPDX expression in jszip 2.5.0.
It causes our CI build failed.
And it was fixed after this PR.
https://github.com/Stuk/jszip/commit/02746afe2118c912160c46f86bde4ca3688d47c4
Can you help to upgrade the library version?

Thanks,
Andy