### PR TITLE
Updating jszip version to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "main": "lib/nodezip.js",
   "dependencies": {
-    "jszip" : "2.5.0"
+    "jszip" : "2.6.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
Updating jszip version to 2.6.1 as earlier version uses protective liccense.